### PR TITLE
Fix for QMM Versionchecker parsing + Fix Gameversion Logger

### DIFF
--- a/QModManager/Checks/VersionCheck.cs
+++ b/QModManager/Checks/VersionCheck.cs
@@ -19,13 +19,13 @@
         {
             if (!Config.CheckForUpdates)
             {
-                Logger.Info("Update check disabled");
+                Logger.Info("QMM Internal Versionchecker: Update check disabled");
                 return;
             }
 
             if (!NetworkUtilities.CheckConnection())
             {
-                Logger.Info("Cannot check for updates, internet disabled");
+                Logger.Info("QMM Internal Versionchecker: Cannot check for updates, internet disabled");
                 return;
             }
 
@@ -37,14 +37,14 @@
                 {
                     if (e.Error != null)
                     {
-                        Logger.Error("There was an error retrieving the latest version from GitHub!");
+                        Logger.Error("QMM Internal Versionchecker: There was an error retrieving the latest version from GitHub!");
                         Logger.Exception(e.Error);
                         return;
                     }
                     Parse(e.Result);
                 };
 
-                Logger.Debug("Getting the latest version...");
+                Logger.Debug("QMM Internal Versionchecker: Getting the latest version...");
                 client.DownloadStringAsync(new Uri(VersionURL));
             }
         }
@@ -56,15 +56,23 @@
                 Version currentVersion = Assembly.GetExecutingAssembly().GetName().Version;
                 if (versionStr == null)
                 {
-                    Logger.Error("There was an error retrieving the latest version from GitHub!");
+                    Logger.Error("QMM Internal Versionchecker: There was an error retrieving the latest version from GitHub!");
                     return;
                 }
-                var latestVersion = new Version(versionStr);
+
+                string[] versionStr_splittet = versionStr.Split('.');
+                string version_builder = $"{versionStr_splittet[0]}.{(versionStr_splittet.Length >= 2 ? $"{versionStr_splittet[1]}" : "0")}.{(versionStr_splittet.Length >= 3 ? $"{versionStr_splittet[2]}" : "0")}.{(versionStr_splittet.Length >= 4 ? $"{versionStr_splittet[3]}" : "0")}";
+                var latestVersion = new Version(version_builder);
+
                 if (latestVersion == null)
                 {
-                    Logger.Error("There was an error retrieving the latest version from GitHub!");
+                    Logger.Error("QMM Internal Versionchecker: There was an error retrieving the latest version from GitHub!");
                     return;
                 }
+                
+                //Logger.Debug($"QMM Version Checker - Parse - current Version value: {currentVersion}");
+                //Logger.Debug($"QMM Version Checker - Parse - latest Version value: {latestVersion}");
+
                 if (latestVersion > currentVersion)
                 {
                     Logger.Info($"Newer version found: {latestVersion.ToStringParsed()} (current version: {currentVersion.ToStringParsed()})");
@@ -72,16 +80,16 @@
                 }
                 else if (latestVersion < currentVersion)
                 {
-                    Logger.Info($"Received latest version from GitHub. We're ahead. This is probably a development build.");
+                    Logger.Info($"QMM Internal Versionchecker: Received latest version from GitHub. We're ahead. This is probably a development build.");
                 }
                 else
                 {
-                    Logger.Info($"Received latest version from GitHub. We are up to date!");
+                    Logger.Info($"QMM Internal Versionchecker: Received latest version from GitHub. We are up to date!");
                 }
             }
             catch (Exception e)
             {
-                Logger.Error("There was an error retrieving the latest version from GitHub!");
+                Logger.Error("QMM Internal Versionchecker: There was an error retrieving the latest version from GitHub!");
                 Logger.Exception(e);
                 return;
             }

--- a/QModManager/Patching/GameDetector.cs
+++ b/QModManager/Patching/GameDetector.cs
@@ -61,7 +61,16 @@
             CurrentGameVersion = SNUtils.GetPlasticChangeSetOfBuild(-1);
 
             Logger.Info($"Game Version: {CurrentGameVersion} Build Date: {SNUtils.GetDateTimeOfBuild():dd-MMMM-yyyy} Store: {StoreDetector.GetUsedGameStore()}");
-            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()}{(IsValidGameRunning && MinimumBuildVersion != 0 ? $" built for {CurrentlyRunningGame} v{MinimumBuildVersion}" : string.Empty)}...");
+
+#if SUBNAUTICA_STABLE
+            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Subnautica v{MinimumBuildVersion}...");
+#elif SUBNAUTICA_EXP
+            Logger.Info($"Loading QModManager -Experimental- v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Subnautica v{MinimumBuildVersion}...");
+#elif BELOWZERO_STABLE
+            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Below Zero v{MinimumBuildVersion}...");
+#elif BELOWZERO_EXP
+            Logger.Info($"Loading QModManager -Experimental- v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Below Zero v{MinimumBuildVersion}...");
+#endif
             Logger.Info($"Today is {DateTime.Now:dd-MMMM-yyyy_HH:mm:ss}");
 
             if (!IsValidGameVersion)

--- a/QModManager/Patching/GameDetector.cs
+++ b/QModManager/Patching/GameDetector.cs
@@ -28,6 +28,7 @@
 
         internal bool IsValidGameRunning => SupportedGameVersions.ContainsKey(CurrentlyRunningGame);
         internal int MinimumBuildVersion => IsValidGameRunning ? SupportedGameVersions[CurrentlyRunningGame] : -1;
+        internal int MinimumBuildVersionofGame(QModGame qModGame) => IsValidGameRunning ? SupportedGameVersions[qModGame] : -1;
         internal bool IsValidGameVersion => IsValidGameRunning && (MinimumBuildVersion == 0 || (CurrentGameVersion > -1 && CurrentGameVersion >= MinimumBuildVersion));
 
         internal GameDetector()
@@ -63,13 +64,13 @@
             Logger.Info($"Game Version: {CurrentGameVersion} Build Date: {SNUtils.GetDateTimeOfBuild():dd-MMMM-yyyy} Store: {StoreDetector.GetUsedGameStore()}");
 
 #if SUBNAUTICA_STABLE
-            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Subnautica v{MinimumBuildVersion}...");
+            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Subnautica v{MinimumBuildVersionofGame(QModGame.Subnautica)}...");
 #elif SUBNAUTICA_EXP
-            Logger.Info($"Loading QModManager -Experimental- v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Subnautica v{MinimumBuildVersion}...");
+            Logger.Info($"Loading QModManager -Experimental- v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Subnautica v{MinimumBuildVersionofGame(QModGame.Subnautica)}...");
 #elif BELOWZERO_STABLE
-            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Below Zero v{MinimumBuildVersion}...");
+            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Below Zero v{MinimumBuildVersionofGame(QModGame.BelowZero)}...");
 #elif BELOWZERO_EXP
-            Logger.Info($"Loading QModManager -Experimental- v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Below Zero v{MinimumBuildVersion}...");
+            Logger.Info($"Loading QModManager -Experimental- v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Below Zero v{MinimumBuildVersionofGame(QModGame.BelowZero)}...");
 #endif
             Logger.Info($"Today is {DateTime.Now:dd-MMMM-yyyy_HH:mm:ss}");
 

--- a/QModManager/Patching/GameDetector.cs
+++ b/QModManager/Patching/GameDetector.cs
@@ -28,7 +28,6 @@
 
         internal bool IsValidGameRunning => SupportedGameVersions.ContainsKey(CurrentlyRunningGame);
         internal int MinimumBuildVersion => IsValidGameRunning ? SupportedGameVersions[CurrentlyRunningGame] : -1;
-        internal int MinimumBuildVersionofGame(QModGame qModGame) => IsValidGameRunning ? SupportedGameVersions[qModGame] : -1;
         internal bool IsValidGameVersion => IsValidGameRunning && (MinimumBuildVersion == 0 || (CurrentGameVersion > -1 && CurrentGameVersion >= MinimumBuildVersion));
 
         internal GameDetector()
@@ -64,13 +63,13 @@
             Logger.Info($"Game Version: {CurrentGameVersion} Build Date: {SNUtils.GetDateTimeOfBuild():dd-MMMM-yyyy} Store: {StoreDetector.GetUsedGameStore()}");
 
 #if SUBNAUTICA_STABLE
-            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Subnautica v{MinimumBuildVersionofGame(QModGame.Subnautica)}...");
+            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Subnautica v{SupportedGameVersions[QModGame.Subnautica]}...");
 #elif SUBNAUTICA_EXP
-            Logger.Info($"Loading QModManager -Experimental- v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Subnautica v{MinimumBuildVersionofGame(QModGame.Subnautica)}...");
+            Logger.Info($"Loading QModManager -Experimental- v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Subnautica v{SupportedGameVersions[QModGame.Subnautica]}...");
 #elif BELOWZERO_STABLE
-            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Below Zero v{MinimumBuildVersionofGame(QModGame.BelowZero)}...");
+            Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Below Zero v{SupportedGameVersions[QModGame.BelowZero]}...");
 #elif BELOWZERO_EXP
-            Logger.Info($"Loading QModManager -Experimental- v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Below Zero v{MinimumBuildVersionofGame(QModGame.BelowZero)}...");
+            Logger.Info($"Loading QModManager -Experimental- v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()} built for Below Zero v{SupportedGameVersions[QModGame.BelowZero]}...");
 #endif
             Logger.Info($"Today is {DateTime.Now:dd-MMMM-yyyy_HH:mm:ss}");
 


### PR DESCRIPTION
Fixed issue when a not Full Qualified Version is provided by the QMM Latest Version file.

Second:
Helper got confused when getting the "wrong Game detection" line in the Logfile while the top says this QMM version was build for the Game X. As this make no sense to display the "running" game version when saying it is build for. I changed that to hardcoded even its look a bit bloated.