### PR TITLE
Added detailed Error Catch for Folder Tree Logger

### DIFF
--- a/QModManager/Utility/IOUtilities.cs
+++ b/QModManager/Utility/IOUtilities.cs
@@ -60,22 +60,29 @@ namespace QModManager.Utility
                 string[] files = Directory.GetFiles(directory);
                 for (int i = 1; i <= files.Length; i++)
                 {
-                    FileInfo fileinfo = new FileInfo(files[i - 1]);
-                    if (i != files.Length)
-                        Console.WriteLine($"{GenerateSpaces(0)}|---- {fileinfo.Name} ({ParseSize(fileinfo.Length)})");
-                    else
-                        Console.WriteLine($"{GenerateSpaces(0)}|---- {fileinfo.Name} ({ParseSize(fileinfo.Length)})");
+                    try
+                    {
+                        FileInfo fileinfo = new FileInfo(files[i - 1]);
+                        if (i != files.Length)
+                            Console.WriteLine($"{GenerateSpaces(0)}|---- {fileinfo.Name} ({ParseSize(fileinfo.Length)})");
+                        else
+                            Console.WriteLine($"{GenerateSpaces(0)}|---- {fileinfo.Name} ({ParseSize(fileinfo.Length)})");
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine($"{GenerateSpaces(0)}|---- ERROR ON GETTING FILE INFORMATION - {e.Message}");
+                    }
                 }
             }
             catch (Exception e)
             {
                 throw e;
             }
-        }
+}
         internal static void WriteFolderStructureRecursively(string directory, int spaces = 0)
         {
             try
-            {
+            { 
                 DirectoryInfo dirInfo = new DirectoryInfo(directory);
                 Console.WriteLine($"{GenerateSpaces(spaces)}|---+ {dirInfo.Name}");
 
@@ -93,11 +100,18 @@ namespace QModManager.Utility
                 string[] files = Directory.GetFiles(directory);
                 for (int i = 1; i <= files.Length; i++)
                 {
-                    FileInfo fileinfo = new FileInfo(files[i - 1]);
-                    if (i != files.Length)
-                        Console.WriteLine($"{GenerateSpaces(spaces + 4)}|---- {fileinfo.Name} ({ParseSize(fileinfo.Length)})");
-                    else
-                        Console.WriteLine($"{GenerateSpaces(spaces + 4)}`---- {fileinfo.Name} ({ParseSize(fileinfo.Length)})");
+                    try
+                    {
+                        FileInfo fileinfo = new FileInfo(files[i - 1]);
+                        if (i != files.Length)
+                            Console.WriteLine($"{GenerateSpaces(spaces + 4)}|---- {fileinfo.Name} ({ParseSize(fileinfo.Length)})");
+                        else
+                            Console.WriteLine($"{GenerateSpaces(spaces + 4)}`---- {fileinfo.Name} ({ParseSize(fileinfo.Length)})");
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine($"{GenerateSpaces(spaces + 4)}|---- ERROR ON GETTING FILE INFORMATION -> {e.Message}");
+                    }
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Added detailed Error Catch for specific File to prevent stopping the hole File Tree logging on a single error.
This should help helpers to still see all the Files.
This idea was initially because a Mod had a ".rar" File in it that caused a IO Exception.